### PR TITLE
renamed few functions to unify interface, reasoning on github

### DIFF
--- a/current/fyne/builtins_fyne.go
+++ b/current/fyne/builtins_fyne.go
@@ -29,7 +29,7 @@ var Builtins_fyne = map[string]*env.Builtin{
 			return *env.NewNative(ps.Idx, app1, "fyne-app")
 		},
 	},
-	"fyne-app//new-window": {
+	"fyne-app//window": {
 		Argsn: 2,
 		Doc:   "Creates new window for and app",
 		Fn: func(ps *env.ProgramState, arg0 env.Object, arg1 env.Object, arg2 env.Object, arg3 env.Object, arg4 env.Object) env.Object {
@@ -261,7 +261,7 @@ var Builtins_fyne = map[string]*env.Builtin{
 		},
 	},
 
-	"fyne-container//add-element": {
+	"fyne-container//add": {
 		Argsn: 2,
 		Doc:   "Adds element from Fyne container",
 		Fn: func(ps *env.ProgramState, arg0 env.Object, arg1 env.Object, arg2 env.Object, arg3 env.Object, arg4 env.Object) env.Object {
@@ -284,7 +284,7 @@ var Builtins_fyne = map[string]*env.Builtin{
 		},
 	},
 
-	"fyne-container//remove-element": {
+	"fyne-container//remove": {
 		Argsn: 2,
 		Doc:   "Removes element from Fyne container",
 		Fn: func(ps *env.ProgramState, arg0 env.Object, arg1 env.Object, arg2 env.Object, arg3 env.Object, arg4 env.Object) env.Object {
@@ -323,7 +323,7 @@ var Builtins_fyne = map[string]*env.Builtin{
 		},
 	},
 
-	"container-vbox": {
+	"vbox": {
 		Argsn: 1,
 		Doc:   "Creates Fyne vbox container",
 		Fn: func(ps *env.ProgramState, arg0 env.Object, arg1 env.Object, arg2 env.Object, arg3 env.Object, arg4 env.Object) env.Object {
@@ -344,7 +344,7 @@ var Builtins_fyne = map[string]*env.Builtin{
 		},
 	},
 
-	"container-hbox": {
+	"hbox": {
 		Argsn: 1,
 		Doc:   "Creates Fyne hbox container",
 		Fn: func(ps *env.ProgramState, arg0 env.Object, arg1 env.Object, arg2 env.Object, arg3 env.Object, arg4 env.Object) env.Object {
@@ -365,7 +365,7 @@ var Builtins_fyne = map[string]*env.Builtin{
 		},
 	},
 
-	"container-grid-rows": {
+	"grid-rows": {
 		Argsn: 2,
 		Doc:   "Creates Fyne grid with rows container",
 		Fn: func(ps *env.ProgramState, arg0 env.Object, arg1 env.Object, arg2 env.Object, arg3 env.Object, arg4 env.Object) env.Object {
@@ -391,7 +391,7 @@ var Builtins_fyne = map[string]*env.Builtin{
 		},
 	},
 
-	"container-grid-cols": {
+	"grid-cols": {
 		Argsn: 2,
 		Doc:   "Creates Fyne grid with cols container",
 		Fn: func(ps *env.ProgramState, arg0 env.Object, arg1 env.Object, arg2 env.Object, arg3 env.Object, arg4 env.Object) env.Object {
@@ -417,7 +417,7 @@ var Builtins_fyne = map[string]*env.Builtin{
 		},
 	},
 
-	"container-center": {
+	"center": {
 		Argsn: 1,
 		Doc:   "Creates Fyne center layout container",
 		Fn: func(ps *env.ProgramState, arg0 env.Object, arg1 env.Object, arg2 env.Object, arg3 env.Object, arg4 env.Object) env.Object {

--- a/examples/fyne/button.rye
+++ b/examples/fyne/button.rye
@@ -4,9 +4,9 @@ rye .needs { fyne }
 do\in fyne { 
 	lab: label "I am a label."
 	btn: button "Click" { lab .set-text "Button was clicked!" }
-	box: container-vbox [ lab btn ]
+	box: vbox [ lab btn ]
 	
-	with app .new-window "Button Demo" {
+	with app .window "Button Demo" {
 		.set-content box ,
 		.show-and-run
 	}

--- a/examples/fyne/calculator.rye
+++ b/examples/fyne/calculator.rye
@@ -4,7 +4,7 @@
 rye .needs { fyne }
 
 do\in fyne {
-    app .new-window "RPN calculator" :window
+    app .window "RPN calculator" :win
 
 	append-a: fn { n } { value-a .get-text .concat n |set-text* value-a }
 	num-button: fn { n } { button n [ 'append-a n ] }
@@ -17,36 +17,36 @@ do\in fyne {
 			value-b .set-text ""
 		}
 	}
-	vbox: container-vbox _           ; this is experimental, might not stay in lang (currying variant)
-	hbox: container-hbox _
+	vbox: vbox _           ; this is experimental, might not stay in lang (currying variant)
+	hbox: hbox _
 
-	cont: container-grid-rows 5 [
+	cont: grid-rows 5 [
 
-        container-grid-cols 3 [
+        grid-cols 3 [
             spacer
-            container-grid-rows 2 [
-                container-grid-cols 2 [ label "B:"  entry :value-b ]
-                container-grid-cols 2 [ label "A:"  entry :value-a ]
+            grid-rows 2 [
+                grid-cols 2 [ label "B:"  entry :value-b ]
+                grid-cols 2 [ label "A:"  entry :value-a ]
             ]
             spacer
         ]
 
-		container-grid-cols 4 [
+		grid-cols 4 [
             num-button "1"  num-button "2"  num-button "3"
             calc-button "/" { / }
         ]
 
-        container-grid-cols 4 [
+        grid-cols 4 [
             num-button "4"  num-button "5"  num-button "6"
             calc-button "*" { * }
         ]
 
-        container-grid-cols 4 [
+        grid-cols 4 [
             num-button "7"  num-button "8"  num-button "9"
             calc-button "-" { - }
         ]
 
-        container-grid-cols 4 [
+        grid-cols 4 [
 			num-button "0"
             button "=" { value-a .get-text .set-text* value-b , value-a |set-text "" }
             button "~" { value-b .get-text .pass { value-a .get-text .set-text* value-b } |set-text* value-a  }
@@ -54,5 +54,5 @@ do\in fyne {
         ]
 	]
 
-	window |set-content cont |resize 400 300 |show-and-run
+	win |set-content cont |resize 400 300 |show-and-run
 }

--- a/examples/fyne/feedback.rye
+++ b/examples/fyne/feedback.rye
@@ -2,13 +2,13 @@
 rye .needs { fyne }
 
 do\in fyne { 
-	cont: container-vbox [
+	cont: vbox [
 		label "Send us feedback:"
 		multiline-entry :ent
 		button "Send" { ent .get-text |printv "Sending: {}" }
 	]
 
-	app .new-window "Feedback"
+	app .window "Feedback"
 	|set-content cont
 	|show-and-run
 }

--- a/examples/fyne/hello.rye
+++ b/examples/fyne/hello.rye
@@ -1,6 +1,6 @@
 rye .needs { fyne }
 
-with fyne/app .new-window "Hello Rye" {
+with fyne/app .window "Hello Rye" {
 	lab: fyne/label "Hello from Rye!" ,
 	.set-content lab ,
 	.show-and-run

--- a/examples/fyne/layout.rye
+++ b/examples/fyne/layout.rye
@@ -3,30 +3,30 @@ rye .needs { fyne }
 
 do\in fyne {
 
-    box: container-grid-cols 2 [
-        container-grid-rows 2 [
-            container-vbox [
+    box: grid-cols 2 [
+        grid-rows 2 [
+            vbox [
                 label "top"
                 label "left"
             ]
-            container-vbox [
+            vbox [
                 label "bottom"
                 label "left"
             ]
         ]
-        container-grid-rows 2 [
-            container-hbox [
+        grid-rows 2 [
+            hbox [
                 label "top"
                 label "right"
             ]
-            container-hbox [
+            hbox [
                 label "bottom"
                 label "right"
             ]
         ]
     ]
 	
-	with app .new-window "Layouts demo" {
+	with app .window "Layouts demo" {
 		.set-content box ,
 		.show-and-run
 	}

--- a/examples/fyne/live.rye
+++ b/examples/fyne/live.rye
@@ -3,7 +3,7 @@ rye .needs { fyne }
 
 do\in fyne { 
 	lab: label "Use the shell, Luke!"
-	win: app .new-window "Live GUI"
+	win: app .window "Live GUI"
 	
 	go fn { } { enter-console "Edit Fyne GUI" }
 	

--- a/examples/fyne/login.rye
+++ b/examples/fyne/login.rye
@@ -2,11 +2,11 @@
 rye .needs { fyne }
 
 do\in fyne {
-	cont: container-grid-rows 3 [
+	cont: grid-rows 3 [
 	    spacer
-	    container-grid-cols 3 [
+	    grid-cols 3 [
             spacer
-            container-vbox [
+            vbox [
                 label "Email:" entry
                 label "Password:"
                 password-entry fn1 { = "mypwd"  }
@@ -17,7 +17,7 @@ do\in fyne {
         spacer
 	]
 
-	app .new-window "Login"
+	app .window "Login"
 	|set-content cont
 	|resize 800 500
 	|show-and-run

--- a/examples/fyne/select-item.rye
+++ b/examples/fyne/select-item.rye
@@ -2,10 +2,10 @@
 rye .needs { fyne }
 
 do\in fyne {
-    app .new-window "Feedback" :window
+    app .window "Feedback" :window
 
-	cont: container-vbox [
-        container-vbox [
+	cont: vbox [
+        vbox [
             label "This"
             label "is"
             label "long"
@@ -19,7 +19,7 @@ do\in fyne {
         radiogroup [ "Radio 1" "Radio 2" "Radio 3" "Radio 4" "Radio 5" "Radio 6" "Radio 7" "Radio 8" ] |vertical-scroll 0 100 :ent-radiogrup
         button "Check radios" { ent-radiogrup .get-text |printv "Radio Group: {}" }
 
-        container-hbox [
+        hbox [
             checkbox "Checkbox 1" :ent-check
             checkbox "Checkbox 2" :ent-check1
             checkbox "Checkbox 3" :ent-check2

--- a/examples/fyne/tabs.rye
+++ b/examples/fyne/tabs.rye
@@ -2,11 +2,12 @@
 rye .needs { fyne }
 
 do\in fyne {
-    app .new-window "Tabs" :window
 
-    tab1: container-vbox [
+	app .window "Tabs" :win
+	
+    tab1: vbox [
         label "Tab 1"
-        container-hbox [
+        hbox [
             label "Button status: "
             button-status: label "Unclicked"
         ]
@@ -14,38 +15,39 @@ do\in fyne {
     ]
 
     prog: progressbar
-    tab2: container-vbox [
+    tab2: vbox [
         label "Tab 2"
-        btn: button "Add progress bar" { tab2 .add-element prog , btn .disable }
-        go does { for range 1 20 { * 0.05 |set-value* prog , sleep 1000 } }
+        btn: button "Add progress bar" {
+			tab2 .add prog , btn .disable
+			go does { for range 1 20 { * 0.05 \set-value* prog , sleep 500 } }
+		}
     ]
 
-    tab3: container-vbox [
+    tab3: vbox [
         label "Tab 3"
         selectbox [ "First" "Second" "Third" ] :ent-select
-        container-hbox [
+        hbox [
             label "Select status: "
             select-status: label "Unselected"
         ]
         button "Check select" { text: ent-select .get-text , select-status .set-text text }
     ]
 
-    content: container-vbox [
+    content: vbox [
         label "Select a tab to view its content"
     ]
 
-    button-row: container-hbox [
-        button "Tab 1" { content .remove-all , content .add-element tab1 }
-        button "Tab 2" { content .remove-all , content .add-element tab2 }
-        button "Tab 3" { content .remove-all , content .add-element tab3 }
+    button-row: hbox [
+        button "Tab 1" { content .remove-all , content .add tab1 }
+        button "Tab 2" { content .remove-all , content .add tab2 }
+        button "Tab 3" { content .remove-all , content .add tab3 }
     ]
 
-    main: container-vbox [
+    main: vbox [
         button-row
         content
     ]
 
-    window
-    |set-content main
-    |show-and-run
+	win .set-content main \show-and-run
+
 }


### PR DESCRIPTION
@markkuhar I renamed few functions according to usual rye naming conventions ...

* All container-* were renamed to *. container-hbox to hbox, container-center to center, etc. We are in Fyne context and hbox, vbox, center, grid are specific enough. There are no other elements than containers with those names
* add-item and remove-item were renamed to add and remove. Both are generic methods, that only dispatch if the first argument is fyne-container (hence fyne-container//add), so the word can be more general, as container can only add items and this doesn't clash with any other function add or remove.
* new-window was renamed to window, because all other constructors use just "noun" word, like label, button, entry, ... not new-label, new-button (in Fyne binding) and in general in Rye currently convention is that constructors are just nouns.